### PR TITLE
download g2p models from gcloud storage

### DIFF
--- a/dhlab_toolkit/g2p/g2p_models.py
+++ b/dhlab_toolkit/g2p/g2p_models.py
@@ -1,0 +1,50 @@
+#%% 
+from pathlib import Path
+from google.cloud import storage
+import phonetisaurus
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+def download_g2p_model(dialect='e', style= "written"):
+    """
+    Download a pre-trained g2p model for a given language.
+    """
+    filename = f"nb_{dialect}_{style}.fst"
+    download_dir = Path.home() / ".cache" / "dhlab_toolkit" 
+    download_dir.mkdir(parents=True, exist_ok=True)
+    download_path = download_dir / filename
+    
+    if not download_path.exists():        
+        try:
+            client = storage.Client()
+            bucket_name = "g2p-models"
+            bucket = client.get_bucket(bucket_name)
+            blob = bucket.blob(filename)
+            blob.download_to_filename(download_path)
+            logging.debug("Download successful.")
+        except Exception as e:
+            logging.error(e)
+            logging.info(f'No pre-trained g2p model available for {dialect} {style}.')
+    
+    logging.debug(f"Path to the G2P model: {download_path}.")
+    return download_path
+
+
+def transcribe(words, dialect='e', style= "written"):
+    """
+    Transcribe a list of words using a pre-trained g2p model.
+    """
+    model_path = download_g2p_model(dialect=dialect, style=style)
+    transcriptions = phonetisaurus.predict(words, model_path = model_path)
+    return transcriptions
+
+
+if __name__ == "__main__":
+    #download_g2p_model(dialect='n', style= "written")
+    result = transcribe(["I", "Nasjonalbiblioteket", "har", "vi", "veldig", "mange", "gamle", "og", "sjeldne", "bøker"])
+    for word, pronunciation in result:
+        print(f"{word}\t{' '.join(pronunciation)}")
+        
+# %%

--- a/dhlab_toolkit/g2p/g2p_models.py
+++ b/dhlab_toolkit/g2p/g2p_models.py
@@ -4,7 +4,19 @@ from google.cloud import storage
 import phonetisaurus
 import logging
 
-logging.basicConfig(level=logging.INFO)
+
+def download_public_file(bucket_name, source_blob_name, destination_file_name):
+    """Downloads a public blob from the bucket."""
+    # bucket_name = "your-bucket-name"
+    # source_blob_name = "storage-object-name"
+    # destination_file_name = "local/path/to/file"
+
+    storage_client = storage.Client.create_anonymous_client()
+
+    bucket = storage_client.bucket(bucket_name)
+    blob = bucket.blob(source_blob_name)
+    blob.download_to_filename(destination_file_name)
+
 
 
 def download_g2p_model(dialect='e', style= "written"):
@@ -15,14 +27,11 @@ def download_g2p_model(dialect='e', style= "written"):
     download_dir = Path.home() / ".cache" / "dhlab_toolkit" 
     download_dir.mkdir(parents=True, exist_ok=True)
     download_path = download_dir / filename
+    bucket_name = "g2p-models"
     
     if not download_path.exists():        
         try:
-            client = storage.Client()
-            bucket_name = "g2p-models"
-            bucket = client.get_bucket(bucket_name)
-            blob = bucket.blob(filename)
-            blob.download_to_filename(download_path)
+            download_public_file(bucket_name, filename, download_path)
             logging.debug("Download successful.")
         except Exception as e:
             logging.error(e)
@@ -42,9 +51,11 @@ def transcribe(words, dialect='e', style= "written"):
 
 
 if __name__ == "__main__":
-    #download_g2p_model(dialect='n', style= "written")
-    result = transcribe(["I", "Nasjonalbiblioteket", "har", "vi", "veldig", "mange", "gamle", "og", "sjeldne", "bøker"])
-    for word, pronunciation in result:
-        print(f"{word}\t{' '.join(pronunciation)}")
-        
+    logging.basicConfig(level=logging.DEBUG)
+
+    download_g2p_model(dialect='t', style= "written")
+    #result = transcribe(["I", "Nasjonalbiblioteket", "har", "vi", "veldig", "mange", "gamle", "og", "sjeldne", "bøker"])
+    #for word, pronunciation in result:
+     #   print(f"{word}\t{' '.join(pronunciation)}")
+    
 # %%

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "dhlab_toolkit"
 version = "0.1.0"
 description = ""
-authors = ["Nasjonalbiblioteket, dhlab@nb.no"]
+authors = ["Nasjonalbiblioteket  <dhlab@nb.no>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
@@ -12,6 +12,8 @@ requests = "^2.31.0"
 pytest = "^7.4.0"
 matplotlib = "^3.7.2"
 seaborn = "^0.12.2"
+phonetisaurus = "^0.3.0"
+google-cloud-storage = "^2.16.0"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
# Grapheme-to-phoneme models

Add new sub-package for using Norwegian dialectal G2P-models: 
- Download models from our Google Cloud Storage bucket to a `~/.cache/dhlab_toolkit` directory. If the model exists in the .cache directory, skip the download and just return the model path. 
- Wrap phonetisaurus.predict:  download/fetch model path + transcribe an input list of words 

## NOTE!
The  google cloud storage client expects application credentials - How should we facilitate access and skip the gcloud authentication step?  Service account? 